### PR TITLE
[COOK-3222] Added optional password length parameter to secure_password

### DIFF
--- a/libraries/secure_password.rb
+++ b/libraries/secure_password.rb
@@ -23,10 +23,10 @@ require 'openssl'
 module Opscode
   module OpenSSL
     module Password
-      def secure_password
+      def secure_password( length = 20 )
         pw = String.new
         
-        while pw.length < 20
+        while pw.length < length
           pw << ::OpenSSL::Random.random_bytes(1).gsub(/\W/, '')
         end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3222

Allow an optional length parameter to be added to secure_password.
If parameter is not provided length is set to 20 characters, exactly how it worked before.
