### PR TITLE
[COOK-3222] Added optional password length parameter (w/ no padding) to secure_password

### DIFF
--- a/libraries/secure_password.rb
+++ b/libraries/secure_password.rb
@@ -23,7 +23,7 @@ require 'openssl'
 module Opscode
   module OpenSSL
     module Password
-      def secure_password( length = 20 )
+      def secure_password(length = 20)
         pw = String.new
         
         while pw.length < length


### PR DESCRIPTION
This is a version of [COOK-3222] with no padding.
