### PR TITLE
Call cert.to_pem before recipe DSL

### DIFF
--- a/providers/x509.rb
+++ b/providers/x509.rb
@@ -12,13 +12,15 @@ attr_reader :key_file, :key, :cert, :ef
 action :create  do
   unless ::File.exists? new_resource.name
     create_keys
+    cert_content = cert.to_pem
+    key_content = key.to_pem
 
     file new_resource.name do
       action :create_if_missing
       mode  new_resource.mode
       owner new_resource.owner
       group new_resource.group
-      content cert.to_pem
+      content cert_content
     end
 
     file new_resource.key_file do
@@ -26,7 +28,7 @@ action :create  do
       mode  new_resource.mode
       owner new_resource.owner
       group new_resource.group
-      content key.to_pem
+      content key_content
     end
 
   end


### PR DESCRIPTION
Fixes #10, calls `#to_pem` on `cert` and `key` before passing local variables to `Chef::Resource::File`.
