### PR TITLE
[#37] Support for Subject Alternative Names on generated self-signed certificates

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -13,7 +13,7 @@ platforms:
     platform: rhel
     run_command: /usr/lib/systemd/systemd
     provision_command:
-      - /bin/yum install -y initscripts net-tools wget
+      - /bin/yum install -y initscripts net-tools wget openssl
 - name: ubuntu-12.04
   driver:
     image: ubuntu-upstart:12.04

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-docker
+  - /opt/chefdk/embedded/bin/chef gem install kitchen-docker chef-sugar
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This LWRP generates self-signed, PEM-formatted x509 certificates. If no existing
 | `org_unit` | String (Required) | Value for the `OU` certificate field. |
 | `country` | String (Required) | Value for the `C` ssl field. |
 | `expire` | Fixnum (Optional) | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period. |
+| `subject_alt_name` | Array (Optional) | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_ |
 | `key_file` | String (Optional) | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the LWRP will attempt to source a key from this location. If no key file is found, the LWRP will generate a new key file at this location. If the `key_file` attribute is not specified, the LWRP will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
 | `key_pass` | String (Optional) | The passphrase for an existing key's passphrase  
 | `key_length` | Fixnum (Optional) | The desired Bit Length of the generated key. _Default: 2048_ |

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -35,14 +35,14 @@ module OpenSSLCookbook
 
     # Generators
     def gen_dhparam(key_length, generator)
-      fail ArgumentError, 'Key length must be a power of 2 greater than or equal to 1024' unless key_length_valid?(key_length)
-      fail TypeError, 'Generator must be an integer' unless generator.is_a?(Integer)
+      raise ArgumentError, 'Key length must be a power of 2 greater than or equal to 1024' unless key_length_valid?(key_length)
+      raise TypeError, 'Generator must be an integer' unless generator.is_a?(Integer)
 
       OpenSSL::PKey::DH.new(key_length, generator)
     end
 
     def gen_rsa_key(key_length)
-      fail ArgumentError, 'Key length must be a power of 2 greater than or equal to 1024' unless key_length_valid?(key_length)
+      raise ArgumentError, 'Key length must be a power of 2 greater than or equal to 1024' unless key_length_valid?(key_length)
 
       OpenSSL::PKey::RSA.new(key_length)
     end
@@ -50,8 +50,8 @@ module OpenSSLCookbook
     # Key manipulation helpers
     # Returns a pem string
     def encrypt_rsa_key(rsa_key, key_password)
-      fail TypeError, 'rsa_key must be a Ruby OpenSSL::PKey::RSA object' unless rsa_key.is_a?(OpenSSL::PKey::RSA)
-      fail TypeError, 'RSA key password must be a string' unless key_password.is_a?(String)
+      raise TypeError, 'rsa_key must be a Ruby OpenSSL::PKey::RSA object' unless rsa_key.is_a?(OpenSSL::PKey::RSA)
+      raise TypeError, 'RSA key password must be a string' unless key_password.is_a?(String)
 
       cipher = OpenSSL::Cipher::Cipher.new('des3')
       rsa_key.to_pem(cipher, key_password)

--- a/libraries/random_password.rb
+++ b/libraries/random_password.rb
@@ -73,7 +73,7 @@ EOH
                when :random_bytes
                  length
                else
-                 fail InvalidPasswordMode.new(mode)
+                 raise InvalidPasswordMode.new(mode)
                end
 
       SecureRandom.send(mode, length).force_encoding(encoding)

--- a/resources/x509.rb
+++ b/resources/x509.rb
@@ -2,15 +2,16 @@
 actions [:create]
 default_action :create
 
-attribute :name,        kind_of: String, name_attribute: true
-attribute :owner,       kind_of: String
-attribute :group,       kind_of: String
-attribute :expire,      kind_of: Integer
-attribute :mode,        kind_of: [Integer, String]
-attribute :org,         kind_of: String, required: true
-attribute :org_unit,    kind_of: String, required: true
-attribute :country,     kind_of: String, required: true
-attribute :common_name, kind_of: String, required: true
-attribute :key_file,    kind_of: String, default: nil
-attribute :key_pass,    kind_of: String, default: nil
-attribute :key_length,  equal_to: [1024, 2048, 4096, 8192], default: 2048
+attribute :name,             kind_of: String, name_attribute: true
+attribute :owner,            kind_of: String
+attribute :group,            kind_of: String
+attribute :expire,           kind_of: Integer
+attribute :mode,             kind_of: [Integer, String]
+attribute :org,              kind_of: String, required: true
+attribute :org_unit,         kind_of: String, required: true
+attribute :country,          kind_of: String, required: true
+attribute :common_name,      kind_of: String, required: true
+attribute :subject_alt_name, kind_of: Array, default: []
+attribute :key_file,         kind_of: String, default: nil
+attribute :key_pass,         kind_of: String, default: nil
+attribute :key_length,       equal_to: [1024, 2048, 4096, 8192], default: 2048

--- a/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
+++ b/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
@@ -45,6 +45,7 @@ openssl_x509 '/etc/ssl_test/mycert.crt' do
   org 'Test Kitchen Example'
   org_unit 'Kitchens'
   country 'UK'
+  subject_alt_name ['IP:127.0.0.1', 'DNS:localhost.localdomain']
 end
 
 # Generate a new certificate from an existing key


### PR DESCRIPTION
I have followed the suggestion of customizing `OpenSSL::Config` from #37 comments, and cargo culted putting the config into `ExtensionFactory` from ruby/openssl's own test suite (https://github.com/ruby/openssl/blob/7ce811a4246f1452ce9d093a72e6cc5cccff50ff/test/test_x509ext.rb#L42-L52). It passes existing test suite, and generates a certificate with valid SAN.
