### PR TITLE
Remove chef-sugar dependency and update testing

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -103,6 +103,9 @@ suites:
 - name: resource_dhparam
   run_list:
   - recipe[test::resource_dhparam]
+- name: upgrade
+  run_list:
+  - recipe[test::upgrade]
 - name: resource_rsa_key
   run_list:
   - recipe[test::resource_rsa_key]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,20 +8,15 @@ platforms:
   - name: centos-5.11
   - name: centos-6.8
   - name: centos-7.2
-  - name: debian-7.10
-    run_list: apt::default
+  - name: debian-7.11
   - name: debian-8.5
-    run_list: apt::default
-  - name: fedora-22
+  - name: fedora-24
     run_list: yum::dnf_yum_compat
-  - name: fedora-23
-    run_list: yum::dnf_yum_compat
+  - name: opensuse-13.2
+  - name: opensuse-leap-42.1
   - name: ubuntu-12.04
-    run_list: apt::default
   - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
-    run_list: apt::default
 
 suites:
 - name: resource_x509
@@ -30,6 +25,9 @@ suites:
 - name: resource_dhparam
   run_list:
   - recipe[test::resource_dhparam]
+- name: upgrade
+  run_list:
+  - recipe[test::upgrade]
 - name: resource_rsa_key
   run_list:
   - recipe[test::resource_rsa_key]

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,25 @@ env:
   - INSTANCE=resource-x509-ubuntu-1204
   - INSTANCE=resource-x509-ubuntu-1404
   - INSTANCE=resource-x509-ubuntu-1604
+  - INSTANCE=resource-x509-debian-7
   - INSTANCE=resource-x509-debian-8
   - INSTANCE=resource-x509-centos-5
   - INSTANCE=resource-x509-centos-6
   - INSTANCE=resource-x509-centos-7
+  - INSTANCE=resource-x509-opensuse-132
+  - INSTANCE=resource-x509-opensuse-421
   - INSTANCE=resource-x509-fedora-latest
-
+  - INSTANCE=upgrade-ubuntu-1204
+  - INSTANCE=upgrade-ubuntu-1404
+  - INSTANCE=upgrade-ubuntu-1604
+  - INSTANCE=upgrade-debian-7
+  - INSTANCE=upgrade-debian-8
+  - INSTANCE=upgrade-centos-5
+  - INSTANCE=upgrade-centos-6
+  - INSTANCE=upgrade-centos-7
+  - INSTANCE=upgrade-opensuse-132
+  - INSTANCE=upgrade-opensuse-421
+  - INSTANCE=upgrade-fedora-latest
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,5 @@ metadata
 
 group :integration do
   cookbook 'test', path: 'test/fixtures/cookbooks/test'
-  cookbook 'apt'
   cookbook 'yum'
 end

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-OpenSSL Cookbook
-================
-[![Build Status](https://travis-ci.org/chef-cookbooks/openssl.svg?branch=master)](http://travis-ci.org/chef-cookbooks/openssl)
-[![Cookbook Version](https://img.shields.io/cookbook/v/openssl.svg)](https://supermarket.chef.io/cookbooks/openssl)
+# OpenSSL Cookbook
+
+[![Build Status](https://travis-ci.org/chef-cookbooks/openssl.svg?branch=master)](http://travis-ci.org/chef-cookbooks/openssl) [![Cookbook Version](https://img.shields.io/cookbook/v/openssl.svg)](https://supermarket.chef.io/cookbooks/openssl)
 
 This cookbook provides tools for working with the Ruby OpenSSL library. It includes:
+
 - A library method to generate secure random passwords in recipes, using the Ruby SecureRandom library.
 - An LWRP for generating RSA private keys.
 - An LWRP for generating x509 certificates.
 - An LWRP for generating dhparam.pem files.
 - An attribute-driven recipe for upgrading OpenSSL packages.
 
-Requirements
-------------
+## Platforms
 
 The `random_password` mixin works on any platform with the Ruby SecureRandom module. This module is already included with Chef.
 
@@ -19,25 +18,24 @@ The `openssl_x509`, `openssl_rsa_key` and `openssl_dhparam` LWRPs work on any pl
 
 The `upgrade` recipe has been tested on the following platforms:
 
-* Ubuntu 12.04, 14.04
-* Debian 7.4
-* CentOS 6.5
+- Debian / Ubuntu derivatives
+- RHEL and derivatives
+- Fedora
+- openSUSE / SUSE Linux Enterprises
 
-The recipe may work on other platforms or different versions of the above platforms, but this has not been tested.
+## Chef
 
-Dependencies
-------------
+- Chef 11+
 
-This cookbook depends on the [Chef Sugar](http://supermarket.chef.io/cookbooks/chef-sugar/) cookbook. [Chef Sugar](http://supermarket.chef.io/cookbooks/chef-sugar/) is used to make the default attribute settings easier to reason about. (See [Attributes](#attributes))
+## Cookbooks
 
-Attributes
-----------
+- none
 
-* `node['openssl']['packages']` - An array of packages required to use openssl. The default attributes attempt to be smart about which packages are the default, but this may need to be changed by users of the `openssl::upgrade` recipe.
-* `node['openssl']['restart_services']` - An array of service resources that depend on the packages listed in the `node['openssl']['packages']` attribute. This array is empty by default, as Chef has no reasonable way to detect which applications or services are compiled against these packages. *Note* Each service listed in this array should represent a "`service`" resource specified in the recipes of the node's run list.
+## Attributes
 
-Recipes
--------
+- `node['openssl']['restart_services']` - An array of service resources that depend on the openssl packages. This array is empty by default, as Chef has no reasonable way to detect which applications or services are compiled against these packages. _Note_ Each service listed in this array should represent a "`service`" resource specified in the recipes of the node's run list.
+
+## Recipes
 
 ### default
 
@@ -64,8 +62,7 @@ include_recipe 'openssl::upgrade'
 
 When executed, this recipe will ensure that openssl is upgraded to the latest version, and that the `stats_collector` service is restarted to pick up the latest security fixes released in the openssl package.
 
-Libraries & LWRPs
------------------
+## Libraries & LWRPs
 
 There are two mixins packaged with this cookbook.
 
@@ -74,6 +71,7 @@ There are two mixins packaged with this cookbook.
 The `RandomPassword` mixin can be used to generate secure random passwords in Chef cookbooks, usually for assignment to a variable or an attribute. `random_password` uses Ruby's SecureRandom library and is customizable.
 
 #### Example Usage
+
 ```ruby
 Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 node.set['my_secure_attribute'] = random_password
@@ -90,6 +88,7 @@ Note that node attributes are widely accessible. Storing unencrypted passwords i
 This library should be considered deprecated and will be removed in a future version. Please use `OpenSSLCookbook::RandomPassword` instead. The documentation is kept here for historical reasons.
 
 #### ~~Example Usage~~
+
 ```ruby
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 node.set_unless['my_password'] = secure_password
@@ -102,19 +101,20 @@ node.set_unless['my_password'] = secure_password
 This LWRP generates self-signed, PEM-formatted x509 certificates. If no existing key is specified, the LWRP will automatically generate a passwordless key with the certificate.
 
 #### Attributes
-| Name  | Type | Description |
-| ----- | ---- | ------------ |
-| `common_name`  | String (Required)  | Value for the `CN` certificate field. |
-| `org` | String (Required) | Value for the `O` certificate field. |
-| `org_unit` | String (Required) | Value for the `OU` certificate field. |
-| `country` | String (Required) | Value for the `C` ssl field. |
-| `expire` | Fixnum (Optional) | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period. |
-| `key_file` | String (Optional) | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the LWRP will attempt to source a key from this location. If no key file is found, the LWRP will generate a new key file at this location. If the `key_file` attribute is not specified, the LWRP will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
-| `key_pass` | String (Optional) | The passphrase for an existing key's passphrase  
-| `key_length` | Fixnum (Optional) | The desired Bit Length of the generated key. _Default: 2048_ |
-| `owner` | String (optional) | The owner of all files created by the LWRP. _Default: "root"_ |
-| `group` | String (optional) | The group of all files created by the LWRP. _Default: "root"_ |
-| `mode` | String or Fixnum (Optional) | The permission mode of all files created by the LWRP.  _Default: "0400"_ |
+
+Name          | Type                        | Description
+------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`common_name` | String (Required)           | Value for the `CN` certificate field.
+`org`         | String (Required)           | Value for the `O` certificate field.
+`org_unit`    | String (Required)           | Value for the `OU` certificate field.
+`country`     | String (Required)           | Value for the `C` ssl field.
+`expire`      | Fixnum (Optional)           | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period.
+`key_file`    | String (Optional)           | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the LWRP will attempt to source a key from this location. If no key file is found, the LWRP will generate a new key file at this location. If the `key_file` attribute is not specified, the LWRP will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
+`key_pass`    | String (Optional)           | The passphrase for an existing key's passphrase
+`key_length`  | Fixnum (Optional)           | The desired Bit Length of the generated key. _Default: 2048_
+`owner`       | String (optional)           | The owner of all files created by the LWRP. _Default: "root"_
+`group`       | String (optional)           | The group of all files created by the LWRP. _Default: "root"_
+`mode`        | String or Fixnum (Optional) | The permission mode of all files created by the LWRP. _Default: "0400"_
 
 #### Example Usage
 
@@ -136,13 +136,14 @@ When executed, this recipe will generate a key certificate at `/etc/httpd/ssl/my
 This LWRP generates dhparam.pem files. If a valid dhparam.pem file is found at the specified location, no new file will be created. If a file is found at the specified location but it is not a valid dhparam file, it will be overwritten.
 
 #### Attributes
-| Name  | Type | Description |
-| ----- | ---- | ------------ |
-| `key_length` | Fixnum (Optional) | The desired Bit Length of the generated key. _Default: 2048_ |
-| `generator` | Fixnum (Optional) | The desired Diffie-Hellmann generator. Can be _2_ or _5_. |
-| `owner` | String (optional) | The owner of all files created by the LWRP. _Default: "root"_ |
-| `group` | String (optional) | The group of all files created by the LWRP. _Default: "root"_ |
-| `mode` | String or Fixnum (Optional) | The permission mode of all files created by the LWRP.  _Default: "0644"_ |
+
+Name         | Type                        | Description
+------------ | --------------------------- | -----------------------------------------------------------------------
+`key_length` | Fixnum (Optional)           | The desired Bit Length of the generated key. _Default: 2048_
+`generator`  | Fixnum (Optional)           | The desired Diffie-Hellmann generator. Can be _2_ or _5_.
+`owner`      | String (optional)           | The owner of all files created by the LWRP. _Default: "root"_
+`group`      | String (optional)           | The group of all files created by the LWRP. _Default: "root"_
+`mode`       | String or Fixnum (Optional) | The permission mode of all files created by the LWRP. _Default: "0644"_
 
 #### Example Usage
 
@@ -150,7 +151,7 @@ In this example, an administrator wishes to create a dhparam.pem file for use wi
 
 ```ruby
 openssl_dhparam '/etc/httpd/ssl/dhparam.pem' do
-  key_length 2048 
+  key_length 2048
   generator 2
 end
 ```
@@ -162,13 +163,14 @@ When executed, this recipe will generate a dhparam file at `/etc/httpd/ssl/dhpar
 This LWRP generates rsa key files. If a valid rsa key file can be opened at the specified location, no new file will be created. If the RSA key file cannot be opened, either because it does not exist or because the password to the RSA key file does not match the password in the recipe, it will be overwritten.
 
 #### Attributes
-| Name  | Type | Description |
-| ----- | ---- | ------------ |
-| `key_length` | Fixnum (Optional) | The desired Bit Length of the generated key. _Default: 2048_ |
-| `key_pass` | String (Optional) | The desired passphrase for the key. |
-| `owner` | String (optional) | The owner of all files created by the LWRP. _Default: "root"_ |
-| `group` | String (optional) | The group of all files created by the LWRP. _Default: "root"_ |
-| `mode` | String or Fixnum (Optional) | The permission mode of all files created by the LWRP.  _Default: "0644"_ |
+
+Name         | Type                        | Description
+------------ | --------------------------- | -----------------------------------------------------------------------
+`key_length` | Fixnum (Optional)           | The desired Bit Length of the generated key. _Default: 2048_
+`key_pass`   | String (Optional)           | The desired passphrase for the key.
+`owner`      | String (optional)           | The owner of all files created by the LWRP. _Default: "root"_
+`group`      | String (optional)           | The group of all files created by the LWRP. _Default: "root"_
+`mode`       | String or Fixnum (Optional) | The permission mode of all files created by the LWRP. _Default: "0644"_
 
 #### Example Usage
 
@@ -176,22 +178,18 @@ In this example, an administrator wishes to create a new RSA private key file in
 
 ```ruby
 openssl_rsa_key '/etc/httpd/ssl/server.key' do
-  key_length 2048 
+  key_length 2048
 end
 ```
 
 When executed, this recipe will generate a passwordless RSA key file at `/etc/httpd/ssl/server.key`.
 
+## License and Author
 
-License and Author
-------------------
-
-Author:: Jesse Nelson (<spheromak@gmail.com>)  
-Author:: Seth Vargo (<sethvargo@gmail.com>)  
-Author:: Charles Johnson (<charles@chef.io>)  
-Author:: Joshua Timberman (<joshua@chef.io>)
-
-=======
+Author:: Jesse Nelson ([spheromak@gmail.com](mailto:spheromak@gmail.com))<br>
+Author:: Seth Vargo ([sethvargo@gmail.com](mailto:sethvargo@gmail.com))<br>
+Author:: Charles Johnson ([charles@chef.io](mailto:charles@chef.io))<br>
+Author:: Joshua Timberman ([joshua@chef.io](mailto:joshua@chef.io))
 
 ```text
 Copyright:: 2009-2016, Chef Software, Inc <legal@chef.io>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: openssl
 # Attributes:: default
 #
-# Copyright 2014, Chef Software, Inc. <legal@chef.io>
+# Copyright 2014-2016, Chef Software, Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,4 @@
 # limitations under the License.
 #
 
-default['openssl']['packages'] = []
 default['openssl']['restart_services'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,10 +9,6 @@ version          '4.4.0'
 recipe 'openssl', 'Empty, this cookbook provides a library, see README.md'
 recipe 'upgrade', 'Upgrade OpenSSL library and restart dependent services'
 
-# chef-sugar greatly reduces the amount of code required to check
-# conditionals for the attributes used in the upgrader recipe.
-depends 'chef-sugar', '>= 3.1.1'
-
 source_url 'https://github.com/chef-cookbooks/openssl' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/openssl/issues' if respond_to?(:issues_url)
 

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -16,22 +16,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'chef-sugar'
 
 # Attributes are set here and not in attributes/default.rb because of the
 # chef-sugar dependency for the methods evaluated in the case statement.
-case
-when debian_before_or_at_squeeze?, ubuntu_before_or_at_lucid?
-  node.default['openssl']['packages'] = %w(libssl0.9.8 openssl)
-when debian_after_or_at_wheezy?, ubuntu_after_or_at_precise?
-  node.default['openssl']['packages'] = %w(libssl1.0.0 openssl)
-when rhel?
-  node.default['openssl']['packages'] = %w(openssl)
+case node['platform_family']
+when 'debian', 'ubuntu'
+  packages = %w(libssl1.0.0 openssl)
+when 'rhel', 'fedora', 'suse'
+  packages = %w(openssl)
 else
-  node.default['openssl']['packages'] = []
+  packages = []
 end
 
-node['openssl']['packages'].each do |ssl_pkg|
+packages.each do |ssl_pkg|
   package ssl_pkg do
     action :upgrade
     node['openssl']['restart_services'].each do |ssl_svc|

--- a/spec/unit/recipes/resource_dhparam_spec.rb
+++ b/spec/unit/recipes/resource_dhparam_spec.rb
@@ -27,7 +27,7 @@ require 'spec_helper'
 
 describe 'test::resource_dhparam' do
   context 'When all attributes are default, on an unspecified platform:' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(step_into: ['openssl_dhparam'])
       runner.converge(described_recipe)
     end

--- a/spec/unit/recipes/resource_rsa_key_spec.rb
+++ b/spec/unit/recipes/resource_rsa_key_spec.rb
@@ -27,7 +27,7 @@ require 'spec_helper'
 
 describe 'test::resource_rsa_key' do
   context 'When all attributes are default, on an unspecified platform:' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(step_into: ['openssl_rsa_key'])
       runner.converge(described_recipe)
     end

--- a/spec/unit/recipes/resource_x509_spec.rb
+++ b/spec/unit/recipes/resource_x509_spec.rb
@@ -27,7 +27,7 @@ require 'spec_helper'
 
 describe 'test::resource_x509' do
   context 'When all attributes are default, on an unspecified platform:' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(step_into: ['openssl_x509'])
       runner.converge(described_recipe)
     end

--- a/test/fixtures/cookbooks/test/recipes/resource_dhparam.rb
+++ b/test/fixtures/cookbooks/test/recipes/resource_dhparam.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+apt_update 'update' if platform_family?('debian')
+
 # Ensure files are not present, so the lwrp makes new keys every time
 file 'any potential existing key' do
   path '/etc/ssl_test/dhparam.pem'

--- a/test/fixtures/cookbooks/test/recipes/resource_rsa_key.rb
+++ b/test/fixtures/cookbooks/test/recipes/resource_rsa_key.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+apt_update 'update' if platform_family?('debian')
+
 # Ensure files are not present, so the lwrp makes new keys every time
 file 'any potential existing unsecured key' do
   path '/etc/ssl_test/rsakey.pem'

--- a/test/fixtures/cookbooks/test/recipes/resource_x509.rb
+++ b/test/fixtures/cookbooks/test/recipes/resource_x509.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+apt_update 'update' if platform_family?('debian')
+
 # Ensure files are not present, so the lwrp makes new keys every time
 file 'Any potential existing cert' do
   path '/etc/ssl_test/mycert.crt'

--- a/test/fixtures/cookbooks/test/recipes/upgrade.rb
+++ b/test/fixtures/cookbooks/test/recipes/upgrade.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: test
-# Recipe:: default
+# Recipe:: upgrade
 #
-# Copyright:: Copyright (c) 2014-2015, Chef Software, Inc. <legal@chef.io>
+# Copyright:: Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,4 +18,6 @@
 # limitations under the License.
 #
 
-execute 'apt-get update' if platform_family?('debian')
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'openssl::upgrade'


### PR DESCRIPTION
use apt_update resource vs. apt cookbook
remove the openssl packages attribute in the upgrade recipe
add support for fedora and suse platforms to the upgrade recipe
test the upgrade recipe in travis CI

Signed-off-by: Tim Smith <tsmith@chef.io>