### PR TITLE
Adding x509 support for /ST and /L

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Name               | Type                        | Description
 `common_name`      | String (Required)           | Value for the `CN` certificate field.
 `org`              | String (Required)           | Value for the `O` certificate field.
 `org_unit`         | String (Required)           | Value for the `OU` certificate field.
+`city`             | String (Optional)           | Value for the `L` certificate field.
+`state`            | String (Optional)           | Value for the `ST` certificate field.
 `country`          | String (Required)           | Value for the `C` ssl field.
 `expire`           | Fixnum (Optional)           | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period.
 `subject_alt_name` | Array (Optional)            | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_

--- a/resources/x509.rb
+++ b/resources/x509.rb
@@ -9,6 +9,8 @@ property :org,              String, required: true
 property :org_unit,         String, required: true
 property :country,          String, required: true
 property :common_name,      String, required: true
+property :state,            String, default: ''
+property :city,             String, default: ''
 property :subject_alt_name, Array, default: []
 property :key_file,         String
 property :key_pass,         String
@@ -77,6 +79,8 @@ action_class do
 
   def subject
     @subject ||= '/C=' + new_resource.country +
+                 (new_resource.state != '' ? '/ST=' + new_resource.state : '') +
+                 (new_resource.city != '' ? '/L=' + new_resource.city : '') +
                  '/O=' + new_resource.org +
                  '/OU=' + new_resource.org_unit +
                  '/CN=' + new_resource.common_name


### PR DESCRIPTION
### Description

This change allows the addition of L= and ST= to x509 certificates

### Issues Resolved



### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
