### PR TITLE
Allow private key passing to x509 & don't generate missing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,33 +75,38 @@ node.normal['my_secure_attribute'] = random_password(length: 50, mode: :base64)
 node.normal['my_secure_attribute'] = random_password(length: 50, mode: :base64, encoding: 'ASCII')
 ```
 
-Note that node attributes are widely accessible. Storing unencrypted passwords in node attributes, as in this example, carries risk.
+**Note**: Node attributes are widely accessible. Storing unencrypted passwords in node attributes, as in this example, carries risk.
 
 ## Resources
 
 ### openssl_x509
 
-This resource generates self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate.
+This resource generates self-signed, PEM-formatted x509 certificates.
 
 #### Properties
 
-Name               | Type                         | Description
------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-`path`             | String (Optional)            | Optional path to write the file to if you'd like to specify it here instead of in the resource name
-`common_name`      | String (Required)            | Value for the `CN` certificate field.
-`org`              | String (Required)            | Value for the `O` certificate field.
-`org_unit`         | String (Required)            | Value for the `OU` certificate field.
-`city`             | String (Optional)            | Value for the `L` certificate field.
-`state`            | String (Optional)            | Value for the `ST` certificate field.
-`country`          | String (Required)            | Value for the `C` ssl field.
-`expire`           | Integer (Optional)           | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period.
-`subject_alt_name` | Array (Optional)             | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_
-`key_file`         | String (Optional)            | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the `key_file` attribute is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
-`key_pass`         | String (Optional)            | The passphrase for an existing key's passphrase
-`key_length`       | Integer (Optional)           | The desired Bit Length of the generated key. _Default: 2048_
-`owner`            | String (optional)            | The owner of all files created by the resource. _Default: "root"_
-`group`            | String (optional)            | The group of all files created by the resource. _Default: "root"_
-`mode`             | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0400"_
+Name                  | Type                                              | Description
+--------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------
+`path`                | String (Optional)                                 | Optional path to write the file to if you'd like to specify it here instead of in the resource name
+`common_name`         | String (Required)                                 | Value for the `CN` certificate field.
+`org`                 | String (Required)                                 | Value for the `O` certificate field.
+`org_unit`            | String (Required)                                 | Value for the `OU` certificate field.
+`city`                | String (Optional)                                 | Value for the `L` certificate field.
+`state`               | String (Optional)                                 | Value for the `ST` certificate field.
+`country`             | String (Required)                                 | Value for the `C` ssl field.
+`expire`              | Integer (Optional)                                | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period.
+`subject_alt_name`    | Array (Optional)                                  | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_
+`private_key_path`    | String (Required unless private_key_content used) | The path to the private key to generate the public key from
+`private_key_content` | String (Required unless private_key_path used)    | The content of the private key including new lines. Used if you don't want to write a private key to disk and use `private_key_path`.
+`private_key_pass`    | String (Optional)                                 | The passphrase for an existing key's passphrase
+`key_length`          | Integer (Optional)                                | The desired Bit Length of the generated key. _Default: 2048_
+`owner`               | String (optional)                                 | The owner of all files created by the resource. _Default: "root"_
+`group`               | String (optional)                                 | The group of all files created by the resource. _Default: "root"_
+`mode`                | String or Integer (Optional)                      | The permission mode of all files created by the resource. _Default: "0400"_
+
+**Note** This resource previously generated private keys if the specified key did not exist. This resource will now fail if the key cannot be found. Use `openssl_rsa_private_key` to generate a key first if necessary.
+
+**Note** key_file/key_pass properties have been renamed `private_key_path` and `private_key_pass`. The previous names will continue to function, but cookbooks should be updated for the new property names.
 
 #### Example Usage
 
@@ -150,7 +155,7 @@ When executed, this recipe will generate a dhparam file at `/etc/httpd/ssl/dhpar
 
 This resource generates rsa private key files. If a valid rsa key file can be opened at the specified location, no new file will be created. If the RSA key file cannot be opened, either because it does not exist or because the password to the RSA key file does not match the password in the recipe, it will be overwritten.
 
-Note: This resource was renamed from openssl_rsa_key to openssl_rsa_private_key. The legacy name will continue to function, but cookbook code should be updated for the new resource name.
+**Note** This resource was renamed from openssl_rsa_key to openssl_rsa_private_key. The legacy name will continue to function, but cookbook code should be updated for the new resource name.
 
 #### Properties
 

--- a/test/fixtures/cookbooks/test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/resources.rb
@@ -64,12 +64,6 @@ openssl_rsa_key '/etc/ssl_test/rsakey_aes128cbc.pem' do
   action :create
 end
 
-# we need to do this with a file resource so that chefspec stepping
-# into openssl_rsa_public_key can function. It's :(
-file '/etc/ssl_test/private_key.pem' do
-  content '-----BEGIN RSA PRIVATE KEY----- Proc-Type: 4,ENCRYPTED DEK-Info: DES-EDE3-CBC,1F2FDA436115C4EE W24gBmtq/Eik2FkSdBh3hF3th3gFq2lMZqSLbho/JVbHFpAQynDbcS9qH5x1fRkt Y7o4A/Sh7noy9kzC1eVIPaQpKFJu5da+uf3t1KxpVMqibzeIE33P9WI+5PzzOm5W xs9shvv/0anU6UMsqBqI+0cmQQ8lw3myTTpO9yWKav2FdTnx7svd+P6BmFknGQaM DYomD0qiB/JzjXbYHLgFspPQXHdyQGhe/YFMlvmjKE0Nut18XJsNwUTWjBA4nRj4 JdlE8XOkWrzIsWKfrBhuhx9bTD0ZVvgssYl2QEh26mv0P0nxx4V/zYx+9U5j0L7q tV4FXfQTgFyctKySuBNi8IT1HFqG9LQps14p8q0XeRigFsRUOVuR0S3eHqg7xiiW QVdF+LgYPpdVNX2mHOSFnHMpFdKLHs8VCNjcGwMNK7avKbne/TJ2NRcL4uhgpsX/ 4tg1kQlwIwtp8MlMqkcinHJ3fjIhWGgjNBVe85NJPVogRDy+c80SqBenaJSavwVA ytmiQOCeon4zhZdscESki+KmsyOWkPB9/zQK76E4ni2IVOL6ZYBMJNTkP47WmA9d Etv7UMxQMI6EYMEH43czvbe4bNCC+hlYotJUM2B52Al7I79W9sSy8cmYi3YZEl0G xtKgY7XwstUBD2XjMuaNyUT0EDjcoa0GhLJSCQkvgn8//BGKaLEyb+Lr+dmHGvxM phCnUKLkfZn9hAFempSJuW4iSaeBKIU3KgYOkBooTuYhXqbN2McoxH6Ec/gnAM5e TIaLiDaHY8IPI4Et5l0sr7v+YF3ZGKC1fL6k4eInNRlhy8oWsFMe79jKkh5wRflt WifTbEdy3D53pVH5lbXyJwpBIOjKJ0OqGWGegu02P5JTsAsniKD+jxNUS8iSOAXL gtpMe4jtqj38hb9D7pBir85Hm+uDqeEuwUqSXAiI+P2F/Jf4ep3h+ek8dcgZtkJQ 3iz92ic2g3M7HW+EE0JcBX+KBwU7yI+UJbWvNQmTXUAYbpoQOLIVm/TrFdGzZ6e9 t0T5wmkE2cS9C3QYiEc7D81nTcTadZChZJDURzUk2REwRGjnunQggHUsj/JKVWqO EPZbpgyDhCaIAkkloWK/SgKny4irMZClhVdeq+v55vDf9nbKR9bgHUb2ZNwp6DQc CPs1BteYthiLtILYzzasMKhlfdoUjEaYziYLGkAQca5XwvwEp0qWg0sMCUUL9pbW 9WzFELBvqNQ1WyIcjb4clcvM0fJdGZ2nKbCAw6zbeSQcGd50NzvTra0xE/J2q6Jo 0V6AGr1Zmu4bJ+tGZCdAIteEO2TosNfS6nrFy15DAe4M4+77ZUGJ8rcwOBopa9qI w7aAyPlfAhrtdSrbOLLp0kRP9EwzSIjSoqc/YJINaNMN8WM7JgnfklmPToT2AqPc 6MOX/Uktag6AXzjcQDtIZSQox326emX1o/huw+7z3/lSXgTdxm3brew/is+9iaQh 5katqPtbec+K/4qydINZSRRFPaoVkg27+6OXvd1AbVS7jmUGHL20xyzA0A9c1csN dm460w4eqbjJEUtDucyIhLPhtYJwPODoRitRmIrzF5DSPrgmSiG93TPiDpRfVPPU -----END RSA PRIVATE KEY-----'
-end
-
 openssl_rsa_public_key '/etc/ssl_test/rsakey_des3.pub' do
   private_key_path '/etc/ssl_test/rsakey_des3.pem'
   private_key_pass 'something'
@@ -86,20 +80,22 @@ end
 # X509 HERE
 #
 
-# Generate new key and certificate
-openssl_x509 '/etc/ssl_test/mycert.crt' do
+# Pass the key as as a string
+openssl_x509 '/etc/ssl_test/rsakey_des3.crt' do
   common_name 'mycert.example.com'
   org 'Test Kitchen Example'
   org_unit 'Kitchens'
   country 'UK'
+  private_key_content "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: DES-EDE3-CBC,5EE0AE9A5FE3342E\n\nyb930kj5/4/nd738dPx6XdbDrMCvqkldaz0rHNw8xsWvwARrl/QSPwROG3WY7ROl\nEUttVlLaeVaqRPfQbmTUfzGI8kTMmDWKjw52gJUx2YJTYRgMHAB0dzYIRjeZAaeS\nypXnEfouVav+jKTmmehr1WuVKbzRhQDBSalzeUwsPi2+fb3Bfuo1dRW6xt8yFuc4\nAkv1hCglymPzPHE2L0nSGjcgA2DZu+/S8/wZ4E63442NHPzO4VlLvpNvJrYpEWq9\nB5mJzcdXPeOTjqd13olNTlOZMaKxu9QShu50GreCTVsl8VRkK8NtwbWuPGBZlIFa\njzlS/RaLuzNzfajaKMkcIYco9t7gN2DwnsACHKqEYT8248Ii3NQ+9/M5YcmpywQj\nWGr0UFCSAdCky1lRjwT+zGQKohr+dVR1GaLem+rSZH94df4YBxDYw4rjsKoEhvXB\nv2Vlx+G7Vl2NFiZzxUKh3MvQLr/NDElpG1pYWDiE0DIG13UqEG++cS870mcEyfFh\nSF2SXYHLWyAhDK0viRDChJyFMduC4E7a2P9DJhL3ZvM0KZ1SLMwROc1XuZ704GwO\nYUqtCX5OOIsTti1Z74jQm9uWFikhgWByhVtu6sYL1YTqtiPJDMFhA560zp/k/qLO\nFKiM4eUWV8AI8AVwT6A4o45N2Ru8S48NQyvh/ADFNrgJbVSeDoYE23+DYKpzbaW9\n00BD/EmUQqaQMc670vmI+CIdcdE7L1zqD6MZN7wtPaRIjx4FJBGsFoeDShr+LoTD\nrwbadwrbc2Rf4DWlvFwLJ4pvNvdtY3wtBu79UCOol0+t8DVVSPVASsh+tp8XncDE\nKRljj88WwBjX7/YlRWvQpe5y2UrsHI0pNy8TA1Xkf6GPr6aS2TvQD5gOrAVReSse\n/kktCzZQotjmY1odvo90Zi6A9NCzkI4ZLgAuhiKDPhxZg61IeLppnfFw0v3H4331\nV9SMYgr1Ftov0++x7q9hFPIHwZp6NHHOhdHNI80XkHqtY/hEvsh7MhFMYCgSY1pa\nK/gMcZ/5Wdg9LwOK6nYRmtPtg6fuqj+jB3Rue5/p9dt4kfom4etCSeJPdvP1Mx2I\neNmyQ/7JN9N87FsfZsIj5OK9OB0fPdj0N0m1mlHM/mFt5UM5x39u13QkCt7skEF+\nyOptXcL629/xwm8eg4EXnKFk330WcYSw+sYmAQ9ZTsBxpCMkz0K4PBTPWWXx63XS\nc4J0r88kbCkMCNv41of8ceeGzFrC74dG7i3IUqZzMzRP8cFeps8auhweUHD2hULs\nXwwtII0YQ6/Fw4hgGQ5//0ASdvAicvH0l1jOQScHzXC2QWNg3GttueB/kmhMeGGm\nsHOJ1rXQ4oEckFvBHOvzjP3kuRHSWFYDx35RjWLAwLCG9odQUApHjLBgFNg9yOR0\njW9a2SGxRvBAfdjTa9ZBBrbjlaF57hq7mXws90P88RpAL+xxCAZUElqeW2Rb2rQ6\nCbz4/AtPekV1CYVodGkPutOsew2zjNqlNH+M8XzfonA60UAH20TEqAgLKwgfgr+a\nc+rXp1AupBxat4EHYJiwXBB9XcVwyp5Z+/dXsYmLXzoMOnp8OFyQ9H8R7y9Y0PEu\n-----END RSA PRIVATE KEY-----\n"
+  private_key_pass 'something'
   subject_alt_name ['IP:127.0.0.1', 'DNS:localhost.localdomain']
 end
 
-# Generate a new certificate from an existing key
+# Pass the key as a path
 openssl_x509 '/etc/ssl_test/mycert2.crt' do
   common_name 'mycert2.example.com'
   org 'Test Kitchen Example'
   org_unit 'Kitchens'
   country 'UK'
-  key_file '/etc/ssl_test/mycert.key'
+  private_key_path '/etc/ssl_test/rsakey_aes128cbc.pem'
 end

--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -8,14 +8,24 @@ describe key_rsa('/etc/ssl_test/rsakey_aes128cbc.pem') do
   its('key_length') { should eq 1024 }
 end
 
+describe key_rsa('/etc/ssl_test/rsakey_des3.pub') do
+  it { should be_public }
+  its('key_length') { should eq 2048 }
+end
+
+describe key_rsa('/etc/ssl_test/rsakey_2.pub') do
+  it { should be_public }
+  its('key_length') { should eq 2048 }
+end
+
 describe command('openssl dhparam -in /etc/ssl_test/dhparam.pem -check -noout') do
   its('exit_status') { should eq 0 }
 end
 
-describe command('openssl rsa -in /etc/ssl_test/mycert.key -check -noout') do
+describe command('openssl x509 -in /etc/ssl_test/rsakey_des3.crt -noout') do
   its('exit_status') { should eq 0 }
 end
 
-describe command('openssl x509 -in /etc/ssl_test/mycert.crt -noout') do
+describe command('openssl x509 -in /etc/ssl_test/mycert2.crt -noout') do
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
We shouldn't just magically generate private keys for you. If they're missing it should fail. This is a breaking change, but it's the right thing to do.

Signed-off-by: Tim Smith <tsmith@chef.io>