### PR TITLE
Fix typo in resources referencing Administrator.

### DIFF
--- a/resources/rsa_private_key.rb
+++ b/resources/rsa_private_key.rb
@@ -7,7 +7,7 @@ property :path,        String, name_property: true
 property :key_length,  equal_to: [1024, 2048, 4096, 8192], default: 2048
 property :key_pass,    String
 property :key_cipher,  String, default: 'des3', equal_to: OpenSSL::Cipher.ciphers
-property :owner,       String, default: node['platform'] == 'windows' ? 'Adminstrator' : 'root'
+property :owner,       String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
 property :group,       String, default: node['root_group']
 property :mode,        [Integer, String], default: '0640'
 property :force,       [true, false], default: false

--- a/resources/rsa_public_key.rb
+++ b/resources/rsa_public_key.rb
@@ -4,7 +4,7 @@ property :path,                String, name_property: true
 property :private_key_path,    String
 property :private_key_content, String
 property :private_key_pass,    String
-property :owner,               String, default: node['platform'] == 'windows' ? 'Adminstrator' : 'root'
+property :owner,               String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
 property :group,               String, default: node['root_group']
 property :mode,                [Integer, String], default: '0640'
 

--- a/resources/x509.rb
+++ b/resources/x509.rb
@@ -1,7 +1,7 @@
 include OpenSSLCookbook::Helpers
 
 property :path,             String, name_property: true
-property :owner,            String, default: node['platform'] == 'windows' ? 'Adminstrator' : 'root'
+property :owner,            String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
 property :group,            String, default: node['root_group']
 property :expire,           Integer
 property :mode,             [Integer, String], default: '0644'


### PR DESCRIPTION
Obvious fix.

### Description

Fix typo in the following fix:
"Fix failures on Windows nodes

Properly default the owner of the files to Administrator on Windows and
root anywhere else"


### Issues Resolved

Issue: https://github.com/chef-cookbooks/openssl/issues/66
Original PR: https://github.com/chef-cookbooks/openssl/commit/b27cd3c5e4276f216951db8370c8c93a50a99c63

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
