### PR TITLE
Rename 'state' to 'state_name' fixing the following exception in Chef 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Name               | Type                         | Description
 `org`              | String (Required)            | Value for the `O` certificate field.
 `org_unit`         | String (Required)            | Value for the `OU` certificate field.
 `city`             | String (Optional)            | Value for the `L` certificate field.
-`state`            | String (Optional)            | Value for the `ST` certificate field.
+`state_name`       | String (Optional)            | Value for the `ST` certificate field.
 `country`          | String (Required)            | Value for the `C` ssl field.
 `expire`           | Integer (Optional)           | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period.
 `subject_alt_name` | Array (Optional)             | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_

--- a/resources/x509.rb
+++ b/resources/x509.rb
@@ -9,7 +9,7 @@ property :org,              String, required: true
 property :org_unit,         String, required: true
 property :country,          String, required: true
 property :common_name,      String, required: true
-property :state,            String
+property :state_name,       String
 property :city,             String
 property :subject_alt_name, Array, default: []
 property :key_file,         String
@@ -79,7 +79,7 @@ action_class do
 
   def subject
     @subject ||= '/C=' + new_resource.country +
-                 '/ST=' + (new_resource.state ? new_resource.state : ' ') +
+                 '/ST=' + (new_resource.state_name ? new_resource.state_name : ' ') +
                  '/L=' + (new_resource.city ? new_resource.city : ' ') +
                  '/O=' + new_resource.org +
                  '/OU=' + new_resource.org_unit +


### PR DESCRIPTION
WARN: Property state of resource openssl_x509 overwrites an existing method.
Please use a different property name. This will raise an exception in Chef 13.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
