### PR TITLE
Add resource x509_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This cookbook provides tools for working with the Ruby OpenSSL library. It inclu
 - A library method to generate secure random passwords in recipes, using the Ruby SecureRandom library.
 - A resource for generating RSA private keys.
 - A resource for generating RSA public keys.
+- A resource for generating EC private keys.
+- A resource for generating EC public keys.
 - A resource for generating x509 certificates.
+- A resource for generating x509 requests.
 - A resource for generating dhparam.pem files.
 - An attribute-driven recipe for upgrading OpenSSL packages.
 
@@ -117,6 +120,44 @@ end
 ```
 
 When executed, this recipe will generate a key certificate at `/etc/httpd/ssl/mycert.key`. It will then use that key to generate a new certificate file at `/etc/httpd/ssl/mycert.pem`.
+
+### openssl_x509_request
+
+
+This resource generates PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate.
+
+
+#### Properties
+
+Name                  | Type                                              | Description
+--------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------
+`path`             | String (Optional)            | Optional path to write the file to if you'd like to specify it here instead of in the resource name
+`common_name`      | String (Required)            | Value for the `CN` certificate field.
+`org`              | String (Optional)            | Value for the `O` certificate field.
+`org_unit`         | String (Optional)            | Value for the `OU` certificate field.
+`city`             | String (Optional)            | Value for the `L` certificate field.
+`state`            | String (Optional)            | Value for the `ST` certificate field.
+`country`          | String (Optional)            | Value for the `C` ssl field.
+`key_file`         | String (Optional)            | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the `key_file` attribute is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
+`key_pass`         | String (Optional)            | The passphrase for an existing key's passphrase
+`key_type`         | String (Optional)            | The desired type of the generated key (rsa or ec). _Default: ec_
+`key_length`       | Integer (Optional)           | The desired Bit Length of the generated key (if key_type is equal to 'rsa'). _Default: 2048_
+`key_curve`        | String (Optional)            | The desired curve of the generated key (if key_type is equal to 'ec'). Run `openssl ecparam -list_curves` to see available options. _Default: prime256v1
+`owner`            | String (optional)            | The owner of all files created by the resource. _Default: "root"_
+`group`            | String (optional)            | The group of all files created by the resource. _Default: "root"_
+`mode`             | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0644"_
+
+
+#### Example Usage
+
+```ruby
+openssl_x509_request '/etc/ssl_test/my_ec_request.csr' do
+  common_name 'myecrequest.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+end
+```
 
 ### openssl_dhparam
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '13.10.0' %>
 
 transport:
   name: dokken

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  require_chef_omnibus: 13.10.0
 
 verifier:
   name: inspec

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -144,5 +144,22 @@ module OpenSSLCookbook
       cipher = OpenSSL::Cipher.new(key_cipher)
       ec_key.to_pem(cipher, key_password)
     end
+
+    # generate a csr pem file given a subject and a private key
+    # @param [OpenSSL::X509::Name] subject the x509 subject object
+    # @param [OpenSSL::PKey::EC, OpenSSL::PKey::RSA] key the private key object
+    # @return [OpenSSL::X509::Request]
+    def gen_x509_request(subject, key)
+      raise TypeError, 'subject must be a Ruby OpenSSL::X509::Name object' unless subject.is_a?(OpenSSL::X509::Name)
+      raise TypeError, 'key must be a Ruby OpenSSL::PKey::EC or a Ruby OpenSSL::PKey::RSA object' unless key.is_a?(OpenSSL::PKey::EC) || key.is_a?(OpenSSL::PKey::RSA)
+
+      request = OpenSSL::X509::Request.new
+      request.version = 0
+      request.subject = subject
+      request.public_key = key
+
+      request.sign(key, OpenSSL::Digest::SHA256.new)
+      request
+    end
   end
 end

--- a/resources/x509_request.rb
+++ b/resources/x509_request.rb
@@ -1,0 +1,81 @@
+include OpenSSLCookbook::Helpers
+
+property :path,             String, name_property: true
+property :owner,            String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
+property :group,            String, default: node['root_group']
+property :mode,             [Integer, String], default: '0644'
+property :country,          String, required: true
+property :state,            String
+property :city,             String
+property :org,              String
+property :org_unit,         String
+property :common_name,      String, required: true
+property :email,            String
+property :key_file,         String
+property :key_pass,         String
+property :key_type,         equal_to: %w(rsa ec), default: 'ec'
+property :key_length,       equal_to: [1024, 2048, 4096, 8192], default: 2048
+property :key_curve,        equal_to: %w(secp384r1 secp521r1 prime256v1), default: 'prime256v1'
+
+default_action :create
+
+action :create do
+  unless ::File.exist? new_resource.path
+    converge_by("Create CSR #{@new_resource}") do
+      file new_resource.name do
+        owner new_resource.owner
+        group new_resource.group
+        mode new_resource.mode
+        content csr.to_pem
+        action :create
+      end
+
+      file new_resource.key_file do
+        mode new_resource.mode
+        owner new_resource.owner
+        group new_resource.group
+        content key.to_pem
+        sensitive true
+        action :create
+      end
+    end
+  end
+end
+
+action_class do
+  def generate_key_file
+    unless new_resource.key_file
+      path, file = ::File.split(new_resource.path)
+      filename = ::File.basename(file, ::File.extname(file))
+      new_resource.key_file path + '/' + filename + '.key'
+    end
+    new_resource.key_file
+  end
+
+  def key
+    @key ||= if priv_key_file_valid?(generate_key_file, new_resource.key_pass)
+               OpenSSL::PKey.read ::File.read(generate_key_file), new_resource.key_pass
+             elsif new_resource.key_type == 'rsa'
+               gen_rsa_priv_key(new_resource.key_length)
+             else
+               gen_ec_priv_key(new_resource.key_curve)
+             end
+    @key
+  end
+
+  def subject
+    csr_subject = OpenSSL::X509::Name.new()
+    csr_subject.add_entry('C', new_resource.country) unless new_resource.country.nil?
+    csr_subject.add_entry('ST', new_resource.state) unless new_resource.state.nil?
+    csr_subject.add_entry('L', new_resource.city) unless new_resource.city.nil?
+    csr_subject.add_entry('O', new_resource.org) unless new_resource.org.nil?
+    csr_subject.add_entry('OU', new_resource.org_unit) unless new_resource.org_unit.nil?
+    csr_subject.add_entry('CN', new_resource.common_name)
+    csr_subject.add_entry('emailAddress', new_resource.email) unless new_resource.email.nil?
+    csr_subject
+  end
+
+  def csr
+    gen_x509_request(subject, key)
+  end
+end

--- a/spec/unit/helpers/helpers_spec.rb
+++ b/spec/unit/helpers/helpers_spec.rb
@@ -325,4 +325,44 @@ describe OpenSSLCookbook::Helpers do
       end
     end
   end
+
+  describe '#gen_x509_request' do
+    before(:all) do
+      @subject = OpenSSL::X509::Name.new [%w(CN x509request)]
+      @ec_key = OpenSSL::PKey::EC.generate('prime256v1')
+      @rsa_key = OpenSSL::PKey::RSA.new(2048)
+    end
+
+    context 'When given anything other than an RSA/EC key object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_request(@subject, 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given anything other than an X509 Name object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_request('abc', @key)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given a valid EC key and a valid subject' do
+      it 'Generates a valid x509 request PEM' do
+        @x509_request = instance.gen_x509_request(@subject, @ec_key)
+        expect(@x509_request).to be_kind_of(OpenSSL::X509::Request)
+        expect(OpenSSL::X509::Request.new(@x509_request).verify(@ec_key)).to be_truthy
+      end
+    end
+
+    context 'When given a valid RSA key and a valid subject' do
+      it 'Generates a valid x509 request PEM' do
+        @x509_request = instance.gen_x509_request(@subject, @rsa_key)
+        expect(@x509_request).to be_kind_of(OpenSSL::X509::Request)
+        expect(OpenSSL::X509::Request.new(@x509_request).verify(@rsa_key)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/unit/recipes/resource_spec.rb
+++ b/spec/unit/recipes/resource_spec.rb
@@ -60,6 +60,41 @@ describe 'test::resources' do
     end
   end
 
+  context 'the openssl_x509_request resource:' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04', step_into: ['openssl_x509_request'])
+      runner.converge(described_recipe)
+    end
+
+    it 'adds a directory resource \'/etc/ssl_test\' with action create' do
+      expect(chef_run).to create_directory('/etc/ssl_test')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_ec_request.csr\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_ec_request.csr')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_ec_request.key\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_ec_request.key')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_ec_request2.csr\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_ec_request2.csr')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_rsa_request.csr\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_rsa_request.csr')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_rsa_request.key\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_rsa_request.key')
+    end
+
+    it 'The resource adds a file resource \'/etc/ssl_test/my_rsa_request2.csr\' with action create' do
+      expect(chef_run).to create_file('/etc/ssl_test/my_rsa_request2.csr')
+    end
+  end
+
   context 'the openssl_rsa_private_key resource:' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04', step_into: ['openssl_rsa_private_key'])

--- a/test/fixtures/cookbooks/test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/resources.rb
@@ -26,6 +26,12 @@
   /etc/ssl_test/mycert.crt
   /etc/ssl_test/mycert.key
   /etc/ssl_test/mycert2.crt
+  /etc/ssl_test/my_ec_request.csr
+  /etc/ssl_test/my_ec_request.key
+  /etc/ssl_test/my_ec_request2.csr
+  /etc/ssl_test/my_rsa_request.csr
+  /etc/ssl_test/my_rsa_request.key
+  /etc/ssl_test/my_rsa_request2.csr
 ).each do |f|
   file "delete existing test file #{f}" do
     path f
@@ -114,4 +120,43 @@ openssl_x509 '/etc/ssl_test/mycert2.crt' do
   org_unit 'Kitchens'
   country 'UK'
   key_file '/etc/ssl_test/mycert.key'
+end
+
+#
+# X509_REQUEST HERE
+#
+
+# Generate new ec key and csr
+openssl_x509_request '/etc/ssl_test/my_ec_request.csr' do
+  common_name 'myecrequest.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+end
+
+# Generate a new csr from an existing ec key
+openssl_x509_request '/etc/ssl_test/my_ec_request2.csr' do
+  common_name 'myecrequest2.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+  key_file '/etc/ssl_test/my_ec_request.key'
+end
+
+# Generate new rsa key and csr
+openssl_x509_request '/etc/ssl_test/my_rsa_request.csr' do
+  common_name 'myrsarequest.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+  key_type 'rsa'
+end
+
+# Generate a new certificate from an existing rsa key
+openssl_x509_request '/etc/ssl_test/my_rsa_request2.csr' do
+  common_name 'myrsarequest2.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+  key_file '/etc/ssl_test/my_ec_request.key'
 end

--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -24,3 +24,27 @@ end
 describe command('openssl x509 -in /etc/ssl_test/mycert.crt -noout') do
   its('exit_status') { should eq 0 }
 end
+
+describe command('openssl ec -in /etc/ssl_test/my_ec_request.key -text -noout') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl rsa -in /etc/ssl_test/my_rsa_request.key -check -noout') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl req -text -noout -verify -in /etc/ssl_test/my_ec_request.csr') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl req -text -noout -verify -in /etc/ssl_test/my_ec_request2.csr') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl req -text -noout -verify -in /etc/ssl_test/my_rsa_request.csr') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl req -text -noout -verify -in /etc/ssl_test/my_rsa_request2.csr') do
+  its('exit_status') { should eq 0 }
+end


### PR DESCRIPTION
### Description

Hello, this is another contribution from the french organization [Institut National de l'Audiovisuel](https://institut.ina.fr)

It add a new resource with documentation & tests :

    openssl_x509_request : Create x509 Certificate Request

I also change the kitchen files because the cookbook isn't working with chef14 (dhparam is now directly included in the chef client).

### Issues Resolved

https://github.com/chef-cookbooks/openssl/issues/60

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
