### PR TITLE
Use the system provided owner/group defaults

### DIFF
--- a/resources/rsa_private_key.rb
+++ b/resources/rsa_private_key.rb
@@ -7,8 +7,8 @@ property :path,        String, name_property: true
 property :key_length,  equal_to: [1024, 2048, 4096, 8192], default: 2048
 property :key_pass,    String
 property :key_cipher,  String, default: 'des3', equal_to: OpenSSL::Cipher.ciphers
-property :owner,       String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
-property :group,       String, default: node['root_group']
+property :owner,       [String, nil]
+property :group,       [String, nil]
 property :mode,        [Integer, String], default: '0640'
 property :force,       [true, false], default: false
 
@@ -27,8 +27,8 @@ action :create do
 
       file new_resource.path do
         action :create
-        owner new_resource.owner
-        group new_resource.group
+        owner new_resource.owner unless new_resource.owner.nil?
+        group new_resource.group unless new_resource.group.nil?
         mode new_resource.mode
         sensitive true
         content rsa_key_content

--- a/resources/rsa_public_key.rb
+++ b/resources/rsa_public_key.rb
@@ -4,8 +4,8 @@ property :path,                String, name_property: true
 property :private_key_path,    String
 property :private_key_content, String
 property :private_key_pass,    String
-property :owner,               String, default: node['platform'] == 'windows' ? 'Administrator' : 'root'
-property :group,               String, default: node['root_group']
+property :owner,               [String, nil]
+property :group,               [String, nil]
 property :mode,                [Integer, String], default: '0640'
 
 action :create do
@@ -17,8 +17,8 @@ action :create do
 
   file new_resource.path do
     action :create
-    owner new_resource.owner
-    group new_resource.group
+    owner new_resource.owner unless new_resource.owner.nil?
+    group new_resource.group unless new_resource.group.nil?
     mode new_resource.mode
     content rsa_key_content
   end


### PR DESCRIPTION
This is how we're doing it in the openssl resources in core and it works a lot better since we don't have to update this resource for any additional platforms that show up in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>