### PR TITLE
openssl_x509_crl resource & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ Name               | Type                         | Description
 `subject_alt_name` | Array (Optional)             | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_
 `key_file`         | String (Optional)            | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the `key_file` attribute is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
 `key_pass`         | String (Optional)            | The passphrase for an existing key's passphrase
-`key_type`         | String (Optional)            | The desired type of the generated key (rsa or ec). _Default: ec_
+`key_type`         | String (Optional)            | The desired type of the generated key (rsa or ec). _Default: rsa_
 `key_length`       | Integer (Optional)           | The desired Bit Length of the generated key (if key_type is equal to 'rsa'). _Default: 2048_
-`key_curve`        | String (Optional)            | The desired curve of the generated key (if key_type is equal to 'ec'). Run `openssl ecparam -list_curves` to see available options. _Default: prime256v1
+`key_curve`        | String (Optional)            | The desired curve of the generated key (if key_type is equal to 'ec'). Run `openssl ecparam -list_curves` to see available options. _Default: prime256v1_
 `csr_file`         | String (Optional)            | The path to a X509 Certificate Request (CSR) on the filesystem. If the `csr_file` attribute is specified, the resource will attempt to source a CSR from this location. If no CSR file is found, the resource will generate a Self-Signed Certificate and the certificate fields must be specified (common_name at last).
 `ca_cert_file`     | String (Optionel)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the certificate will be signed with them.
 `ca_key_file`      | String (Optionel)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the certificate will be signed with them.
 `ca_key_pass`      | String (Optionel)            | The passphrase for CA private key's passphrase
 `owner`            | String (optional)            | The owner of all files created by the resource. _Default: "root"_
 `group`            | String (optional)            | The group of all files created by the resource. _Default: "root"_
-`mode`             | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0400"_
+`mode`             | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0644"_
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Name               | Type                         | Description
 `key_length`       | Integer (Optional)           | The desired Bit Length of the generated key (if key_type is equal to 'rsa'). _Default: 2048_
 `key_curve`        | String (Optional)            | The desired curve of the generated key (if key_type is equal to 'ec'). Run `openssl ecparam -list_curves` to see available options. _Default: prime256v1_
 `csr_file`         | String (Optional)            | The path to a X509 Certificate Request (CSR) on the filesystem. If the `csr_file` attribute is specified, the resource will attempt to source a CSR from this location. If no CSR file is found, the resource will generate a Self-Signed Certificate and the certificate fields must be specified (common_name at last).
-`ca_cert_file`     | String (Optionel)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the certificate will be signed with them.
-`ca_key_file`      | String (Optionel)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the certificate will be signed with them.
-`ca_key_pass`      | String (Optionel)            | The passphrase for CA private key's passphrase
+`ca_cert_file`     | String (Optional)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the certificate will be signed with them.
+`ca_key_file`      | String (Optional)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the certificate will be signed with them.
+`ca_key_pass`      | String (Optional)            | The passphrase for CA private key's passphrase
 `owner`            | String (optional)            | The owner of all files created by the resource. _Default: "root"_
 `group`            | String (optional)            | The group of all files created by the resource. _Default: "root"_
 `mode`             | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0644"_
@@ -212,9 +212,9 @@ Name                  | Type                                              | Desc
 `revokation_reason`  | String or Integer(Optional)  | [Reason of the revokation]((https://en.wikipedia.org/wiki/Certificate_revocation_list#Reasons_for_revocation)) _Default: 0_
 `expire`             | Integer (Optional)           | Value representing the number of days from _now_ through which the issued CRL will remain valid. The CRL will expire after this period. _Default: 8_
 `renewal_threshold`  | Integer (Optional)           | Number of days before the expiration. It this threshold is reached, the CRL will be renewed _Default: 1_
-`ca_cert_file`       | String (Optionel)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the CRL will be signed with them.
-`ca_key_file`        | String (Optionel)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the CRL will be signed with them.
-`ca_key_pass`        | String (Optionel)            | The passphrase for CA private key's passphrase
+`ca_cert_file`       | String (Required)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the CRL will be signed with them.
+`ca_key_file`        | String (Required)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the CRL will be signed with them.
+`ca_key_pass`        | String (Optional)            | The passphrase for CA private key's passphrase
 `owner`              | String (optional)            | The owner of all files created by the resource. _Default: "root"_
 `group`              | String (optional)            | The group of all files created by the resource. _Default: "root"_
 `mode`               | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0644"_

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This cookbook provides tools for working with the Ruby OpenSSL library. It inclu
 - A resource for generating EC public keys.
 - A resource for generating x509 certificates.
 - A resource for generating x509 requests.
+- A resource for generating x509 crl.
 - A resource for generating dhparam.pem files.
 - An attribute-driven recipe for upgrading OpenSSL packages.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Name               | Type                         | Description
 `country`          | String (Optional)            | Value for the `C` ssl field.
 `email`            | String (Optional)            | Value for the `email` ssl field.
 `expire`           | Integer (Optional)           | Value representing the number of days from _now_ through which the issued certificate cert will remain valid. The certificate will expire after this period. _Default: 365
-`extensions`       | Hash (Optional)              | Hash of X509 Extensions entries, in format `{ 'keyUsage' => { 'values' => %w( keyEncipherment digitalSignature), 'critical' => true } }`
+`extensions`       | Hash (Optional)              | Hash of X509 Extensions entries, in format `{ 'keyUsage' => { 'values' => %w( keyEncipherment digitalSignature), 'critical' => true } }` _Default: empty_
 `subject_alt_name` | Array (Optional)             | Array of _Subject Alternative Name_ entries, in format `DNS:example.com` or `IP:1.2.3.4` _Default: empty_
 `key_file`         | String (Optional)            | The path to a certificate key file on the filesystem. If the `key_file` attribute is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the `key_file` attribute is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
 `key_pass`         | String (Optional)            | The passphrase for an existing key's passphrase
@@ -160,9 +160,7 @@ When executed, this recipe will generate a key certificate at `/etc/ssl_test/my_
 
 ### openssl_x509_request
 
-
 This resource generates PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate.
-
 
 #### Properties
 
@@ -187,6 +185,8 @@ Name                  | Type                                              | Desc
 
 #### Example Usage
 
+In this example, an administrator wishes to create a x509 CRL. In order to create the CRL, the administrator crafts this recipe:
+
 ```ruby
 openssl_x509_request '/etc/ssl_test/my_ec_request.csr' do
   common_name 'myecrequest.example.com'
@@ -197,6 +197,50 @@ end
 ```
 
 When executed, this recipe will generate a key certificate at `/etc/httpd/ssl/my_ec_request.key`. It will then use that key to generate a new csr file at `/etc/ssl_test/my_ec_request.csr`.
+
+### openssl_x509_crl
+
+This resource generates PEM-formatted x509 CRL.
+
+#### Properties
+
+Name                  | Type                                              | Description
+--------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------
+`path`               | String (Optional)            | Optional path to write the file to if you'd like to specify it here instead of in the resource name
+`serial_to_revoke`   | String or Integer(Optional)  | Serial of the X509 Certificate to revoke
+`revokation_reason`  | String or Integer(Optional)  | [Reason of the revokation]((https://en.wikipedia.org/wiki/Certificate_revocation_list#Reasons_for_revocation)) _Default: 0_
+`expire`             | Integer (Optional)           | Value representing the number of days from _now_ through which the issued CRL will remain valid. The CRL will expire after this period. _Default: 8_
+`renewal_threshold`  | Integer (Optional)           | Number of days before the expiration. It this threshold is reached, the CRL will be renewed _Default: 1_
+`ca_cert_file`       | String (Optionel)            | The path to the CA X509 Certificate on the filesystem. If the `ca_cert_file` attribute is specified, the `ca_key_file` attribute must also be specified, the CRL will be signed with them.
+`ca_key_file`        | String (Optionel)            | The path to the CA private key on the filesystem. If the `ca_key_file` attribute is specified, the `ca_cert_file' attribute must also be specified, the CRL will be signed with them.
+`ca_key_pass`        | String (Optionel)            | The passphrase for CA private key's passphrase
+`owner`              | String (optional)            | The owner of all files created by the resource. _Default: "root"_
+`group`              | String (optional)            | The group of all files created by the resource. _Default: "root"_
+`mode`               | String or Integer (Optional) | The permission mode of all files created by the resource. _Default: "0644"_
+
+
+#### Example Usage
+
+In this example, an administrator wishes to create an empty X509 CRL. In order to create the CRL, the administrator crafts this recipe:
+
+```ruby
+openssl_x509_crl '/etc/ssl_test/my_ca.crl' do
+  ca_cert_file '/etc/ssl_test/my_ca.crt'
+  ca_key_file '/etc/ssl_test/my_ca.key'
+end
+```
+
+When executed, this recipe will generate a new CRL file at `/etc/ssl_test/my_ca.crl`.
+
+In this example, an administrator wishes to revoke a certificate in an existing X509 CRL.
+
+```ruby
+openssl_x509_crl '/etc/ssl_test/my_ca.crl' do
+  ca_cert_file '/etc/ssl_test/my_ca.crt'
+  ca_key_file '/etc/ssl_test/my_ca.key'
+  serial_to_revoke C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F
+end
+```
 
 ### openssl_dhparam
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This cookbook provides tools for working with the Ruby OpenSSL library. It inclu
 
 ## Chef
 
-- Chef 13.0+
+- Chef 12.7+
 
 ## Cookbooks
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This cookbook provides tools for working with the Ruby OpenSSL library. It inclu
 
 ## Chef
 
-- Chef 12.7+
+- Chef 13.0+
 
 ## Cookbooks
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -18,6 +18,8 @@ platforms:
   driver:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/yum -y install diffutils
 
 - name: debian-8
   driver:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,7 +47,7 @@ module OpenSSLCookbook
       rescue OpenSSL::PKey::PKeyError, ArgumentError
         return false
       end
-      
+
       if key.is_a?(OpenSSL::PKey::EC)
         key.private_key?
       else

--- a/resources/ec_public_key.rb
+++ b/resources/ec_public_key.rb
@@ -13,9 +13,9 @@ default_action :create
 action :create do
   raise ArgumentError, "You cannot specify both 'private_key_path' and 'private_key_content' properties at the same time." if new_resource.private_key_path && new_resource.private_key_content
   raise ArgumentError, "You must specify the private key with either 'private_key_path' or 'private_key_content' properties." unless new_resource.private_key_path || new_resource.private_key_content
-  raise "#{new_resource.private_key_path} not a valid private RSA key or password is invalid" unless priv_key_file_valid?((new_resource.private_key_path || new_resource.private_key_content), new_resource.private_key_pass)
+  raise "#{new_resource.private_key_path} not a valid private EC key or password is invalid" unless priv_key_file_valid?((new_resource.private_key_path || new_resource.private_key_content), new_resource.private_key_pass)
 
-  ec_key_content = gen_ec_public_key((new_resource.private_key_path || new_resource.private_key_content), new_resource.private_key_pass)
+  ec_key_content = gen_ec_pub_key((new_resource.private_key_path || new_resource.private_key_content), new_resource.private_key_pass)
 
   file new_resource.name do
     action :create

--- a/resources/x509_crl.rb
+++ b/resources/x509_crl.rb
@@ -1,0 +1,69 @@
+include OpenSSLCookbook::Helpers
+
+property :path,              String, name_property: true
+property :serial_to_revoke,  [Integer, String]
+property :revocation_reason, Integer, default: 0
+property :expire,            Integer, default: 8
+property :renewal_threshold, Integer, default: 1
+property :ca_cert_file,      String, required: true
+property :ca_key_file,       String, required: true
+property :ca_key_pass,       String
+property :owner,             String, default: 'root'
+property :group,             String, default: 'root'
+property :mode,              String, default: '0644'
+
+action :create do
+  file new_resource.path do
+    owner new_resource.owner
+    group new_resource.group
+    mode new_resource.mode
+    content crl.to_pem
+    action :create
+  end
+end
+
+action_class do
+  def crl_info
+    # Will contain issuer & expiration
+    crl_info = {}
+
+    crl_info['issuer'] = OpenSSL::X509::Certificate.new ::File.read(new_resource.ca_cert_file)
+    crl_info['validity'] = new_resource.expire
+
+    crl_info
+  end
+
+  def revoke_info
+    # Will contain Serial to revoke & reason
+    revoke_info = {}
+
+    revoke_info['serial'] = new_resource.serial_to_revoke
+    revoke_info['reason'] = new_resource.revocation_reason
+
+    revoke_info
+  end
+
+  def ca_private_key
+    ca_private_key = OpenSSL::PKey.read ::File.read(new_resource.ca_key_file), new_resource.ca_key_pass
+    ca_private_key
+  end
+
+  def crl
+    if crl_file_valid?(new_resource.path)
+      crl = OpenSSL::X509::CRL.new ::File.read(new_resource.path)
+    else
+      log "Creating a CRL #{new_resource.path} for CA #{new_resource.ca_cert_file}"
+      crl = gen_x509_crl(ca_private_key, crl_info)
+    end
+
+    if !new_resource.serial_to_revoke.nil? && serial_revoked?(crl, new_resource.serial_to_revoke) == false
+      log "Revoking serial #{new_resource.serial_to_revoke} in CRL #{new_resource.path}"
+      crl = revoke_x509_crl(revoke_info, crl, ca_private_key, crl_info)
+    elsif crl.next_update <= Time.now + 3600 * 24 * new_resource.renewal_threshold
+      log "Renewing CRL for CA #{new_resource.ca_cert_file}"
+      crl = renew_x509_crl(crl, ca_private_key, crl_info)
+    end
+
+    crl
+  end
+end

--- a/spec/unit/helpers/helpers_spec.rb
+++ b/spec/unit/helpers/helpers_spec.rb
@@ -171,6 +171,40 @@ describe OpenSSLCookbook::Helpers do
     end
   end
 
+  describe '#crl_file_valid?' do
+    require 'tempfile'
+
+    before(:each) do
+      @crlfile = Tempfile.new('crlfile')
+    end
+
+    context 'When the crl file doesnt not exist' do
+      it 'returns false' do
+        expect(instance.crl_file_valid?('/tmp/bad_filename')).to be_falsey
+      end
+    end
+
+    context 'When the crl file does exist, but does not contain a valid CRL' do
+      it 'returns false' do
+        @crlfile.write('I_am_not_a_crl_I_am_a_free_man')
+        @crlfile.close
+        expect(instance.crl_file_valid?(@crlfile.path)).to be_falsey
+      end
+    end
+
+    context 'When the crl file does exist, and does contain a vaild CRL' do
+      it 'returns true' do
+        @crlfile.write("-----BEGIN X509 CRL-----\nMIIBbjCB0QIBATAKBggqhkjOPQQDAjAOMQwwCgYDVQQDDANDQTIXDTE4MDgwMTE3\nMjg1NVoXDTE4MDgwOTE3Mjg1NVowNjA0AhUAx7y2YCouQlHvTignoijLUrwM6i8X\nDTE4MDgwMTE3Mjg1NVowDDAKBgNVHRUEAwoBAKBaMFgwCgYDVR0UBAMCAQQwSgYD\nVR0jBEMwQYAUCqE8XxFIFys0LTVPvsO1UtmrlyOhEqQQMA4xDDAKBgNVBAMMA0NB\nMoIVAPneTuAa1LzrK0wiZrxE8/1lSTp3MAoGCCqGSM49BAMCA4GLADCBhwJBct+Z\nZV3IZkPNevQv2S8lZ6kAMudN8R4QSzIQfM354Uk880RyQStP2S5Mb4gW3aFzwAy2\n/+rbx0bn2WmwoQv17I8CQgDtbvhf9chyPgMwAGCF7al04fve90fU1zRNH0zX1j9H\niDA2q1uBX+3TcTWcN+xgNimeRpvJFJ3uOB6w7jtwqGf1YQ==\n-----END X509 CRL-----\n")
+        @crlfile.close
+        expect(instance.crl_file_valid?(@crlfile.path)).to be_truthy
+      end
+    end
+
+    after(:each) do
+      @crlfile.unlink
+    end
+  end
+
   # Generators
   describe '#gen_dhparam' do
     context 'When given an invalid key length' do
@@ -489,6 +523,319 @@ describe OpenSSLCookbook::Helpers do
         @x509_certificate = instance.gen_x509_cert(@ec_request, @x509_extension, @info_with_issuer, @ca_key)
         expect(@x509_certificate).to be_kind_of(OpenSSL::X509::Certificate)
         expect(OpenSSL::X509::Certificate.new(@x509_certificate).verify(@ca_key)).to be_truthy
+      end
+    end
+  end
+
+  describe '#get_next_crl_number' do
+    include OpenSSLCookbook::Helpers
+    before(:all) do
+      @crl = OpenSSL::X509::CRL. new "-----BEGIN X509 CRL-----\nMIIBbTCB0QIBATAKBggqhkjOPQQDAjAOMQwwCgYDVQQDDANDQTIXDTE4MDgwMjA5\nMzc0OFoXDTE4MDgxMDA5Mzc0OFowNjA0AhUAx7y2YCouQlHvTignoijLUrwM6i8X\nDTE4MDgwMjA5Mzc0OFowDDAKBgNVHRUEAwoBAKBaMFgwCgYDVR0UBAMCAQQwSgYD\nVR0jBEMwQYAUxRlLNQUIOeWVaYm6HS0qFIbNCs2hEqQQMA4xDDAKBgNVBAMMA0NB\nMoIVAN1nyw8cj7IbhRLBu2CfS9Q8ILmDMAoGCCqGSM49BAMCA4GKADCBhgJBNR3o\njo/PzFwFGJKxIMa09pU+jprLG2CWehpZ4tGDjwiDCfZBztkg3H15eu+hyWmDp0U9\neAP5iJHVb12/3KZP0YUCQSgmaoLF68+Gh7ha+hcDjwFhzqdgmh/UlGPaxFBJ1BiQ\nQq9uBn0IT4o7v1Tv2WRZNDk7oiuRaZG+R9IodiZPsGKv\n-----END X509 CRL-----\n"
+    end
+
+    context 'When the CRL given is anything other then a Ruby OpenSSL::X509::CRL object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.get_next_crl_number('abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given valid parameter to get the next crlNumber' do
+      it 'Get 5' do
+        @next_crl = instance.get_next_crl_number(@crl)
+        expect(@next_crl).to be_kind_of(Integer)
+        expect(@next_crl == 5).to be_truthy
+      end
+    end
+  end
+
+  describe '#serial_revoked?' do
+    include OpenSSLCookbook::Helpers
+    before(:all) do
+      @crl = OpenSSL::X509::CRL. new "-----BEGIN X509 CRL-----\nMIIBbTCB0QIBATAKBggqhkjOPQQDAjAOMQwwCgYDVQQDDANDQTIXDTE4MDgwMjA5\nMzc0OFoXDTE4MDgxMDA5Mzc0OFowNjA0AhUAx7y2YCouQlHvTignoijLUrwM6i8X\nDTE4MDgwMjA5Mzc0OFowDDAKBgNVHRUEAwoBAKBaMFgwCgYDVR0UBAMCAQQwSgYD\nVR0jBEMwQYAUxRlLNQUIOeWVaYm6HS0qFIbNCs2hEqQQMA4xDDAKBgNVBAMMA0NB\nMoIVAN1nyw8cj7IbhRLBu2CfS9Q8ILmDMAoGCCqGSM49BAMCA4GKADCBhgJBNR3o\njo/PzFwFGJKxIMa09pU+jprLG2CWehpZ4tGDjwiDCfZBztkg3H15eu+hyWmDp0U9\neAP5iJHVb12/3KZP0YUCQSgmaoLF68+Gh7ha+hcDjwFhzqdgmh/UlGPaxFBJ1BiQ\nQq9uBn0IT4o7v1Tv2WRZNDk7oiuRaZG+R9IodiZPsGKv\n-----END X509 CRL-----\n"
+    end
+
+    context 'When the CRL given is anything other then a Ruby OpenSSL::X509::CRL object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.serial_revoked?('abc', 'C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the serial given is anything other then a Ruby String or Integer object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.serial_revoked?(@crl, [])
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given valid parameters to know if the serial is revoked' do
+      it 'get true' do
+        @serial_revoked = instance.serial_revoked?(@crl, 'C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F')
+        expect(@serial_revoked).to be_kind_of(TrueClass)
+      end
+    end
+  end
+
+  describe '#gen_x509_crl' do
+    include OpenSSLCookbook::Helpers
+    before(:all) do
+      # Generating CA
+      @ca_key = OpenSSL::PKey::RSA.new(2048)
+      @ca_cert = OpenSSL::X509::Certificate.new
+      @ca_cert.version = 2
+      @ca_cert.serial = 1
+      @ca_cert.subject = OpenSSL::X509::Name.new [%w(CN TestCA)]
+      @ca_cert.issuer = @ca_cert.subject
+      @ca_cert.public_key = @ca_key.public_key
+      @ca_cert.not_before = Time.now
+      @ca_cert.not_after = @ca_cert.not_before + 365 * 24 * 60 * 60
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = @ca_cert
+      ef.issuer_certificate = @ca_cert
+      @ca_cert.add_extension(ef.create_extension('basicConstraints', 'CA:TRUE', true))
+      @ca_cert.add_extension(ef.create_extension('keyUsage', 'keyCertSign, cRLSign', true))
+      @ca_cert.add_extension(ef.create_extension('subjectKeyIdentifier', 'hash', false))
+      @ca_cert.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always', false))
+      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+
+      @info = { 'validity' => 8, 'issuer' => @ca_cert }
+    end
+
+    context 'When the CA private key given is anything other then a Ruby OpenSSL::PKey::EC object or a OpenSSL::PKey::RSA object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_crl('abc', @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the info given is anything other then a Ruby Hash' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_crl(@ca_key, 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When a misformatted info Ruby Hash is given' do
+      it 'Raises a ArgumentError' do
+        expect do
+          instance.gen_x509_crl(@ca_key, 'abc' => 'def', 'validity' => 8)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_crl(@ca_key, 'issuer' => 'abc', 'validity' => 8)
+        end.to raise_error(TypeError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.gen_x509_crl(@ca_key, 'issuer' => @ca_cert, 'validity' => 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given valid parameters to generate a CRL' do
+      it 'Generates a valid x509 CRL' do
+        @x509_crl = instance.gen_x509_crl(@ca_key, @info)
+        expect(@x509_crl).to be_kind_of(OpenSSL::X509::CRL)
+        expect(OpenSSL::X509::CRL.new(@x509_crl).verify(@ca_key)).to be_truthy
+      end
+    end
+  end
+
+  describe '#renew_x509_crl' do
+    include OpenSSLCookbook::Helpers
+    before(:all) do
+      # Generating CA
+      @ca_key = OpenSSL::PKey::RSA.new(2048)
+      @ca_cert = OpenSSL::X509::Certificate.new
+      @ca_cert.version = 2
+      @ca_cert.serial = 1
+      @ca_cert.subject = OpenSSL::X509::Name.new [%w(CN TestCA)]
+      @ca_cert.issuer = @ca_cert.subject
+      @ca_cert.public_key = @ca_key.public_key
+      @ca_cert.not_before = Time.now
+      @ca_cert.not_after = @ca_cert.not_before + 365 * 24 * 60 * 60
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = @ca_cert
+      ef.issuer_certificate = @ca_cert
+      @ca_cert.add_extension(ef.create_extension('basicConstraints', 'CA:TRUE', true))
+      @ca_cert.add_extension(ef.create_extension('keyUsage', 'keyCertSign, cRLSign', true))
+      @ca_cert.add_extension(ef.create_extension('subjectKeyIdentifier', 'hash', false))
+      @ca_cert.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always', false))
+      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+
+      @info = { 'validity' => 8, 'issuer' => @ca_cert }
+
+      @crl = gen_x509_crl(@ca_key, @info)
+    end
+
+    context 'When the CRL given is anything other then a Ruby OpenSSL::X509::CRL object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.renew_x509_crl('abc', @ca_key, @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the CA private key given is anything other then a Ruby OpenSSL::PKey::EC object or a OpenSSL::PKey::RSA object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.renew_x509_crl(@crl, 'abc', @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the info given is anything other then a Ruby Hash' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.renew_x509_crl(@crl, @ca_key, 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When a misformatted info Ruby Hash is given' do
+      it 'Raises a ArgumentError' do
+        expect do
+          instance.renew_x509_crl(@crl, @ca_key, 'abc' => 'def', 'validity' => 8)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.renew_x509_crl(@crl, @ca_key, 'issuer' => 'abc', 'validity' => 8)
+        end.to raise_error(TypeError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.renew_x509_crl(@crl, @ca_key, 'issuer' => @ca_cert, 'validity' => 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given valid parameters to renew a CRL' do
+      it 'Renew a valid x509 CRL' do
+        @renewed_crl = instance.renew_x509_crl(@crl, @ca_key, @info)
+        expect(@renewed_crl).to be_kind_of(OpenSSL::X509::CRL)
+        expect(OpenSSL::X509::CRL.new(@renewed_crl).verify(@ca_key)).to be_truthy
+      end
+    end
+  end
+
+  describe '#revoke_x509_crl' do
+    include OpenSSLCookbook::Helpers
+    before(:all) do
+      # Generating CA
+      @ca_key = OpenSSL::PKey::RSA.new(2048)
+      @ca_cert = OpenSSL::X509::Certificate.new
+      @ca_cert.version = 2
+      @ca_cert.serial = 1
+      @ca_cert.subject = OpenSSL::X509::Name.new [%w(CN TestCA)]
+      @ca_cert.issuer = @ca_cert.subject
+      @ca_cert.public_key = @ca_key.public_key
+      @ca_cert.not_before = Time.now
+      @ca_cert.not_after = @ca_cert.not_before + 365 * 24 * 60 * 60
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = @ca_cert
+      ef.issuer_certificate = @ca_cert
+      @ca_cert.add_extension(ef.create_extension('basicConstraints', 'CA:TRUE', true))
+      @ca_cert.add_extension(ef.create_extension('keyUsage', 'keyCertSign, cRLSign', true))
+      @ca_cert.add_extension(ef.create_extension('subjectKeyIdentifier', 'hash', false))
+      @ca_cert.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always', false))
+      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+
+      @info = { 'validity' => 8, 'issuer' => @ca_cert }
+
+      @crl = gen_x509_crl(@ca_key, @info)
+      @revoke_info = { 'serial' => 1, 'reason' => 0 }
+    end
+
+    context 'When the revoke_info given is anything other then a Ruby Hash' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl('abc', @crl, @ca_key, @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the CRL given is anything other then a Ruby OpenSSL::X509::CRL object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, 'abc', @ca_key, @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the CA private key given is anything other then a Ruby OpenSSL::PKey::EC object or a OpenSSL::PKey::RSA object' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, @crl, 'abc', @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When the info given is anything other then a Ruby Hash' do
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, @crl, @ca_key, 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When a misformatted revoke_info Ruby Hash is given' do
+      it 'Raises a ArgumentError' do
+        expect do
+          instance.revoke_x509_crl({ 'abc' => 'def', 'ghi' => 'jkl' }, @crl, @ca_key, @info)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl({ 'serial' => [], 'reason' => 0 }, @crl, @ca_key, @info)
+        end.to raise_error(TypeError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl({ 'serial' => 1, 'reason' => 'abc' }, @crl, @ca_key, @info)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When a misformatted info Ruby Hash is given' do
+      it 'Raises a ArgumentError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, @crl, @ca_key, 'abc' => 'def', 'validity' => 8)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, @crl, @ca_key, 'issuer' => 'abc', 'validity' => 8)
+        end.to raise_error(TypeError)
+      end
+
+      it 'Raises a TypeError' do
+        expect do
+          instance.revoke_x509_crl(@revoke_info, @crl, @ca_key, 'issuer' => @ca_cert, 'validity' => 'abc')
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'When given valid parameters to revoke a Serial in a CRL' do
+      it 'Revoke a Serial in a CRL' do
+        @crl_with_revoked_serial = instance.revoke_x509_crl(@revoke_info, @crl, @ca_key, @info)
+        expect(@crl_with_revoked_serial).to be_kind_of(OpenSSL::X509::CRL)
+        expect(OpenSSL::X509::CRL.new(@crl_with_revoked_serial).verify(@ca_key)).to be_truthy
+        expect(serial_revoked?(@crl_with_revoked_serial, 1)).to be_truthy
       end
     end
   end

--- a/test/fixtures/cookbooks/test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/resources.rb
@@ -38,6 +38,7 @@
   /etc/ssl_test/my_ca2.key
   /etc/ssl_test/my_ca2.csr
   /etc/ssl_test/my_ca2.crt
+  /etc/ssl_test/my_ca2.crl
   /etc/ssl_test/my_signed_cert2.key
   /etc/ssl_test/my_signed_cert2.csr
   /etc/ssl_test/my_signed_cert2.crt
@@ -242,6 +243,28 @@ openssl_x509_certificate '/etc/ssl_test/my_signed_cert2.crt' do
     }
   )
   subject_alt_name ['IP:127.0.0.1', 'DNS:localhost.localdomain']
+end
+
+#
+# X509_CRL HERE
+#
+
+openssl_x509_crl '/etc/ssl_test/my_ca2.crl' do
+  ca_cert_file '/etc/ssl_test/my_ca2.crt'
+  ca_key_file '/etc/ssl_test/my_ca2.key'
+  expire 1
+end
+
+openssl_x509_crl '/etc/ssl_test/my_ca2.crl' do
+  ca_cert_file '/etc/ssl_test/my_ca2.crt'
+  ca_key_file '/etc/ssl_test/my_ca2.key'
+  renewal_threshold 2
+end
+
+openssl_x509_crl '/etc/ssl_test/my_ca2.crl' do
+  ca_cert_file '/etc/ssl_test/my_ca2.crt'
+  ca_key_file '/etc/ssl_test/my_ca2.key'
+  serial_to_revoke 'C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F'
 end
 
 #

--- a/test/fixtures/cookbooks/test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/resources.rb
@@ -21,7 +21,12 @@
 %w(
   /etc/ssl_test/rsakey_des3.pem
   /etc/ssl_test/rsakey_aes128cbc.pem
+  /etc/ssl_test/private_key.pem
+  /etc/ssl_test/rsakey_des3.pub
+  /etc/ssl_test/rsakey_2.pub
   /etc/ssl_test/eckey_prime256v1_des3.pem
+  /etc/ssl_test/eckey_prime256v1_des3.pub
+  /etc/ssl_test/eckey_prime256v1_des3_2.pub
   /etc/ssl_test/dhparam.pem
   /etc/ssl_test/mycert.crt
   /etc/ssl_test/mycert.key
@@ -107,6 +112,17 @@ end
 openssl_ec_private_key '/etc/ssl_test/eckey_prime256v1_des3.pem' do
   key_curve 'prime256v1'
   key_pass 'something'
+  action :create
+end
+
+openssl_ec_public_key '/etc/ssl_test/eckey_prime256v1_des3.pub' do
+  private_key_path '/etc/ssl_test/eckey_prime256v1_des3.pem'
+  private_key_pass 'something'
+  action :create
+end
+
+openssl_ec_public_key '/etc/ssl_test/eckey_prime256v1_des3_2.pub' do
+  private_key_content "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEII2VAU9re44mAUzYPWCg+qqwdmP8CplsEg0b/DYPXLg2oAoGCCqGSM49\nAwEHoUQDQgAEKkpMCbIQ2C6Qlp/B+Odp1a9Y06Sm8yqPvCVIkWYP7M8PX5+RmoIv\njGBVf/+mVBx77ji3NpTilMUt2KPZ87lZ3w==\n-----END EC PRIVATE KEY-----\n"
   action :create
 end
 

--- a/test/fixtures/cookbooks/test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/resources.rb
@@ -303,5 +303,5 @@ openssl_x509_request '/etc/ssl_test/my_rsa_request2.csr' do
   org 'Test Kitchen Example'
   org_unit 'Kitchens'
   country 'UK'
-  key_file '/etc/ssl_test/my_ec_request.key'
+  key_file '/etc/ssl_test/my_rsa_request.key'
 end

--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -220,6 +220,12 @@ describe x509_certificate('/etc/ssl_test/my_signed_cert2.crt') do
   its('extensions.subjectAltName') { should include 'IP Address:127.0.0.1' }
 end
 
+# X509 CRL
+describe command('openssl crl -in /etc/ssl_test/my_ca2.crl -text -noout | grep Serial') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F/ }
+end
+
 # X509 REQUESTS
 
 describe command('openssl ec -in /etc/ssl_test/my_ec_request.key -text -noout') do

--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -15,6 +15,19 @@ describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3.pem -text -
   its('stdout') { should match /prime256v1/ }
 end
 
+describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3.pem -pubout -out /tmp/ec_pub && diff /etc/ssl_test/eckey_prime256v1_des3.pub /tmp/ec_pub') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3v2.pem -text -noout -passin pass:"something"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /prime256v1/ }
+end
+
+describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3v2.pem -pubout -out /tmp/ec_pub && diff /etc/ssl_test/eckey_prime256v1_des3v2.pub /tmp/ec_pub') do
+  its('exit_status') { should eq 0 }
+end
+
 describe command('openssl dhparam -in /etc/ssl_test/dhparam.pem -check -noout') do
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -15,16 +15,7 @@ describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3.pem -text -
   its('stdout') { should match /prime256v1/ }
 end
 
-describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3.pem -pubout -out /tmp/ec_pub && diff /etc/ssl_test/eckey_prime256v1_des3.pub /tmp/ec_pub') do
-  its('exit_status') { should eq 0 }
-end
-
-describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3v2.pem -text -noout -passin pass:"something"') do
-  its('exit_status') { should eq 0 }
-  its('stdout') { should match /prime256v1/ }
-end
-
-describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3v2.pem -pubout -out /tmp/ec_pub && diff /etc/ssl_test/eckey_prime256v1_des3v2.pub /tmp/ec_pub') do
+describe command('openssl ec -in /etc/ssl_test/eckey_prime256v1_des3.pem -passin pass:"something" -pubout -out /tmp/ec_pub && diff /etc/ssl_test/eckey_prime256v1_des3.pub /tmp/ec_pub') do
   its('exit_status') { should eq 0 }
 end
 


### PR DESCRIPTION
### Description

Hello, this is another contribution from the french organization [Institut National de l'Audiovisuel](https://institut.ina.fr).

It adds a new resource with documentation & tests :

- openssl_x509_crl

It also fixed a few bugs :

- fix openssl_ec_public_key with documentation & tests
- few corrections in the documentation
- fix backward compatibility with chef client 12

This is our last big modification. :-)

### Issues Resolved

https://github.com/chef-cookbooks/openssl/issues/72

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>