### PR TITLE
Avoid deprecation warnings on Chef 14.3+

### DIFF
--- a/resources/dhparam.rb
+++ b/resources/dhparam.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_dhparam
+
 include OpenSSLCookbook::Helpers
 
 property :path,        String, name_property: true

--- a/resources/ec_private_key.rb
+++ b/resources/ec_private_key.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_ec_private_key
+
 include OpenSSLCookbook::Helpers
 
 property :path,        String, name_property: true

--- a/resources/ec_public_key.rb
+++ b/resources/ec_public_key.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_ec_public_key
+
 include OpenSSLCookbook::Helpers
 
 property :path,                String, name_property: true

--- a/resources/rsa_private_key.rb
+++ b/resources/rsa_private_key.rb
@@ -1,5 +1,22 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_rsa_private_key
 provides :openssl_rsa_key # legacy name
-provides :openssl_rsa_private_key
 
 include OpenSSLCookbook::Helpers
 

--- a/resources/rsa_public_key.rb
+++ b/resources/rsa_public_key.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_rsa_public_key
+
 include OpenSSLCookbook::Helpers
 
 property :path,                String, name_property: true

--- a/resources/x509_certificate.rb
+++ b/resources/x509_certificate.rb
@@ -1,5 +1,23 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_x509_certificate
+
 provides :openssl_x509 # legacy_name
-provides :openssl_x509_certificate
 
 include OpenSSLCookbook::Helpers
 

--- a/resources/x509_crl.rb
+++ b/resources/x509_crl.rb
@@ -1,3 +1,22 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_x509_crl
+
 include OpenSSLCookbook::Helpers
 
 property :path,              String, name_property: true

--- a/resources/x509_request.rb
+++ b/resources/x509_request.rb
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :openssl_x509_request
+
 include OpenSSLCookbook::Helpers
 
 property :path,             String, name_property: true


### PR DESCRIPTION
Don't load the resources unless we're on a version of Chef that doesn't
have them built in.

Signed-off-by: Tim Smith <tsmith@chef.io>